### PR TITLE
Fix consistent headings and navigation structure

### DIFF
--- a/bespoke.html
+++ b/bespoke.html
@@ -26,14 +26,15 @@
 								<ul>
 									<li><a class="icon solid fa-home" href="index.html"><span>Home</span></a></li>
 									<li>
-										<a href="#" class="icon fa-chart-bar"><span>Coaching Programmes</span></a>
+										<a href="#" class="icon fa-music"><span>Music Lessons</span></a>
 										<ul>
-											<li><a href="clarity.html">Career Coaching</a></li>
-											<li><a href="mindset.html">Mindset Coaching</a></li>
-											<li><a href="bespoke.html">Bespoke Coaching</a></li>
+											<li><a href="clarity.html">Piano Lessons</a></li>
+											<li><a href="mindset.html">Violin Lessons</a></li>
+											<li><a href="music-theory.html">Music Theory</a></li>
 										</ul>
 									</li>
-									<li><a class="icon solid fa-cog" href="left-sidebar.html"><span>What Is Coaching?</span></a></li>
+									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> -->
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>

--- a/clarity.html
+++ b/clarity.html
@@ -31,10 +31,10 @@
 											<li><a href="clarity.html">Piano Lessons</a></li>
 											<li><a href="mindset.html">Violin Lessons</a></li>
 											<li><a href="music-theory.html">Music Theory</a></li>
-											<li><a href="bespoke.html">Combined Lessons</a></li>
 										</ul>
 									</li>
 									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> -->
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>

--- a/index.html
+++ b/index.html
@@ -31,10 +31,10 @@
 											<li><a href="clarity.html">Piano Lessons</a></li>
 											<li><a href="mindset.html">Violin Lessons</a></li>
 											<li><a href="music-theory.html">Music Theory</a></li>
-											<li><a href="bespoke.html">Combined Lessons</a></li>
 										</ul>
 									</li>
 									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> -->
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>
@@ -58,7 +58,7 @@
 										<header>
 											<h3>Piano Lessons</h3>
 										</header>
-										<p>Comprehensive piano instruction covering classical and popular styles. From beginner to advanced levels.</p>
+										<p>Comprehensive piano instruction covering classical and popular styles. Expert guidance for all skill levels from complete beginners to advanced players.</p>
 									</section>
 
 							</div>
@@ -92,9 +92,9 @@
 									<section>
 										<a href="bespoke.html" class="image featured"><img src="images/pic03.jpg" alt="" /></a>
 										<header>
-											<h3>Combined Lessons</h3>
+											<h3>Bespoke Coaching</h3>
 										</header>
-										<p>Learn multiple aspects of music with integrated lessons that combine instruments and theory.</p>
+										<p>Personalised coaching that combines music instruction with individual development. Tailored approach for achieving your musical and personal goals.</p>
 									</section>
 
 							</div>

--- a/left-sidebar.html
+++ b/left-sidebar.html
@@ -31,10 +31,10 @@
 											<li><a href="clarity.html">Piano Lessons</a></li>
 											<li><a href="mindset.html">Violin Lessons</a></li>
 											<li><a href="music-theory.html">Music Theory</a></li>
-											<li><a href="bespoke.html">Combined Lessons</a></li>
 										</ul>
 									</li>
 									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> -->
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>

--- a/mindset.html
+++ b/mindset.html
@@ -31,10 +31,10 @@
 											<li><a href="clarity.html">Piano Lessons</a></li>
 											<li><a href="mindset.html">Violin Lessons</a></li>
 											<li><a href="music-theory.html">Music Theory</a></li>
-											<li><a href="bespoke.html">Combined Lessons</a></li>
 										</ul>
 									</li>
 									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> --> 
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>

--- a/music-theory.html
+++ b/music-theory.html
@@ -31,10 +31,10 @@
 											<li><a href="clarity.html">Piano Lessons</a></li>
 											<li><a href="mindset.html">Violin Lessons</a></li>
 											<li><a href="music-theory.html">Music Theory</a></li>
-											<li><a href="bespoke.html">Combined Lessons</a></li>
 										</ul>
 									</li>
 									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> -->
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>

--- a/no-sidebar.html
+++ b/no-sidebar.html
@@ -26,14 +26,15 @@
 								<ul>
 									<li><a class="icon solid fa-home" href="index.html"><span>Home</span></a></li>
 									<li>
-										<a href="#" class="icon fa-chart-bar"><span>Coaching Programmes</span></a>
+										<a href="#" class="icon fa-music"><span>Music Lessons</span></a>
 										<ul>
-											<li><a href="clarity.html">Career Coaching</a></li>
-											<li><a href="mindset.html">Mindset Coaching</a></li>
-											<li><a href="bespoke.html">Bespoke Coaching</a></li>
+											<li><a href="clarity.html">Piano Lessons</a></li>
+											<li><a href="mindset.html">Violin Lessons</a></li>
+											<li><a href="music-theory.html">Music Theory</a></li>
 										</ul>
 									</li>
-									<li><a class="icon solid fa-cog" href="left-sidebar.html"><span>What Is coaching?</span></a></li>
+									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> -->
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>

--- a/right-sidebar.html
+++ b/right-sidebar.html
@@ -27,14 +27,15 @@
 								<ul>
 									<li><a class="icon solid fa-home" href="index.html"><span>Home</span></a></li>
 									<li>
-										<a href="#" class="icon fa-chart-bar"><span>Coaching Programmes</span></a>
+										<a href="#" class="icon fa-music"><span>Music Lessons</span></a>
 										<ul>
-											<li><a href="clarity.html">Career Coaching</a></li>
-											<li><a href="mindset.html">Mindset Coaching</a></li>
-											<li><a href="bespoke.html">Bespoke Coaching</a></li>
+											<li><a href="clarity.html">Piano Lessons</a></li>
+											<li><a href="mindset.html">Violin Lessons</a></li>
+											<li><a href="music-theory.html">Music Theory</a></li>
 										</ul>
 									</li>
-									<li><a class="icon solid fa-cog" href="left-sidebar.html"><span>What Is Coaching</span></a></li>
+									<li><a class="icon solid fa-info" href="left-sidebar.html"><span>Teaching Approach</span></a></li>
+									<li><a class="icon solid fa-chart-bar" href="bespoke.html"><span>Bespoke Coaching</span></a></li>
 									<!-- <li><a class="icon solid fa-retweet" href="right-sidebar.html"><span>Blog</span></a></li> -->
 									<li><a class="icon solid fa-sitemap" href="no-sidebar.html"><span>About Me</span></a></li>
 								</ul>


### PR DESCRIPTION
Implements the changes requested in issue #11:

- Replace all instances of 'combined lessons' with 'bespoke coaching' across all pages
- Move bespoke coaching from Music Lessons submenu to separate top-level navigation link
- Standardize navigation order: Home, Music Lessons, Teaching Approach, Bespoke Coaching, About Me
- Balance text lengths in home page feature boxes for consistent sizing

Generated with [Claude Code](https://claude.ai/code)