### PR TITLE
Remove contact forms, fix button sizing, standardise British English

### DIFF
--- a/bespoke.html
+++ b/bespoke.html
@@ -83,30 +83,10 @@
 							<h2>Book your bespoke coaching consultation <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -114,10 +94,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>

--- a/clarity.html
+++ b/clarity.html
@@ -64,7 +64,7 @@
 										<li>Basic music theory as it applies to piano playing</li>
 										<li>Reading music notation and developing sight-reading skills</li>
 										<li>Classical repertoire from Bach to modern masters</li>
-										<li>Popular music and your favorite songs</li>
+										<li>Popular music and your favourite songs</li>
 										<li>Performance skills, ABRSM exam preparation, and confidence building</li>
 										<li>Creative musical exploration</li>
 									</ul>
@@ -87,30 +87,10 @@
 							<h2>Book your first piano lesson <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -118,10 +98,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
 											<a href="#" class="image featured"><img src="images/pic04.jpg" alt="" /></a>
 											<ul>
 												<li>You've always wanted to learn violin or piano but never knew where to start.</li>
-												<li>You're looking for personalized instruction tailored to your learning style and goals.</li>
+												<li>You're looking for personalised instruction tailored to your learning style and goals.</li>
 												<li>You want to develop proper technique from the beginning or improve existing skills.</li>
 												<li>You're interested in exploring different musical genres and styles.</li>
 												<li>You want to build confidence and enjoy making music in a supportive environment.</li>
@@ -140,7 +140,7 @@
 												<h2><a href="#">What Makes My Teaching <strong>Special</strong>?
 												</a></h2>
 												<ul>
-													<li>Personalized lesson plans designed around your musical interests and learning pace.</li>
+													<li>Personalised lesson plans designed around your musical interests and learning pace.</li>
 													<li>Strong foundation in proper technique combined with creative musical exploration.</li>
 													<li>Experience teaching students of all ages, from young children to adult beginners.</li>
 													<li>Regular progress assessments and performance opportunities to build confidence.</li>
@@ -165,30 +165,10 @@
 							<h2>Book your first lesson or send a message <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -196,10 +176,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>

--- a/left-sidebar.html
+++ b/left-sidebar.html
@@ -74,30 +74,10 @@
 							<h2>Book your first lesson <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -105,10 +85,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>

--- a/mindset.html
+++ b/mindset.html
@@ -58,7 +58,7 @@
 									combine technical excellence with musical artistry, helping you develop both the skill and passion 
 									necessary to make beautiful music.</p>
 									<p>Whether you're a complete beginner or looking to advance your existing skills, I provide 
-									personalized instruction that focuses on proper technique, musical understanding, and the joy 
+									personalised instruction that focuses on proper technique, musical understanding, and the joy 
 									of creating beautiful sounds. Each lesson is tailored to your individual goals and learning style.</p>
 									<p>From your very first lesson, you'll begin developing the foundation that will serve you 
 									throughout your musical journey, building confidence and skills that will last a lifetime.</p>
@@ -92,30 +92,10 @@
 							<h2>Book your first violin lesson <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -123,10 +103,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>

--- a/music-theory.html
+++ b/music-theory.html
@@ -89,30 +89,10 @@
 							<h2>Book your first music theory lesson <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -120,10 +100,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>

--- a/no-sidebar.html
+++ b/no-sidebar.html
@@ -76,30 +76,10 @@
 							<h2>Send a message or book a free Consultation Call <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -107,10 +87,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>

--- a/right-sidebar.html
+++ b/right-sidebar.html
@@ -228,30 +228,10 @@
 							<h2>Send a message or book a free Consultation Call <strong>today</strong></h2>
 						</header>
 						<div class="row">
-							<div class="col-6 col-12-medium">
-								<section>
-									<form method="post" action="mailto:bespoke.music.coaching@gmail.com">
-										<div class="row gtr-50">
-											<div class="col-6 col-12-small">
-												<input name="name" placeholder="Name" type="text" />
-											</div>
-											<div class="col-6 col-12-small">
-												<input name="email" placeholder="Email" type="text" />
-											</div>
-											<div class="col-12">
-												<textarea name="message" placeholder="Message"></textarea>
-											</div>
-											<div class="col-12">
-												<input class="form-button-submit button icon solid fa-envelope" type="submit" value="Send Message">
-											</div>
-										</div>
-									</form>
-								</section>
-							</div>
-							<div class="col-6 col-12-medium">
+							<div class="col-12 col-12-medium">
 								<section>
 									<div class="row">
-										<div class="col-6 col-12-small">
+										<div class="col-12">
 											<ul class="icons">
 												<li class="icon solid fa-phone">
 													+44735 207 1661
@@ -259,10 +239,6 @@
 												<li class="icon solid fa-envelope">
 													<a href="mailto:bespoke.music.coaching@gmail.com">bespoke.music.coaching@gmail.com</a>
 												</li>
-											</ul>
-										</div>
-										<div class="col-6 col-12-small">
-											<ul class="icons">
 											</ul>
 										</div>
 									</div>


### PR DESCRIPTION
This PR addresses issue #23 with the following changes:

- ✅ Removed contact forms from all pages while preserving telephone and email with icons
- ✅ Verified music theory button sizing matches other lesson buttons (already correct)
- ✅ Standardised spelling to British English throughout the site

Generated with [Claude Code](https://claude.ai/code)