### PR TITLE
Center contact links in footer

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2688,6 +2688,11 @@ input, select, textarea {
 
 				#footer ul.icons {
 					margin-bottom: 0;
+					text-align: center;
+					display: flex;
+					justify-content: center;
+					flex-direction: column;
+					align-items: center;
 				}
 
 		/* Copyright */


### PR DESCRIPTION
Centers the telephone number and email address links with their icons at the bottom of each page.

Changes:
- Added flexbox centering styles to footer ul.icons in main.css
- Centers both phone and email contact information horizontally
- Applied across all pages via CSS update

Fixes #25

Generated with [Claude Code](https://claude.ai/code)