### PR TITLE
Make piano, violin and sheet music images same aspect ratio

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1507,6 +1507,15 @@ input, select, textarea {
 			display: block;
 			width: 100%;
 			margin: 0 0 3.5em 0;
+			aspect-ratio: 4 / 3;
+			overflow: hidden;
+		}
+
+		.image.featured img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			object-position: center;
 		}
 
 		.image.left {
@@ -2569,6 +2578,15 @@ input, select, textarea {
 
 			.image.featured {
 				margin: 0 0 1.5em 0;
+				aspect-ratio: 4 / 3;
+				overflow: hidden;
+			}
+
+			.image.featured img {
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+				object-position: center;
 			}
 
 			.image.left {


### PR DESCRIPTION
This PR addresses issue #27 by making the piano, violin, and sheet music images have consistent aspect ratios.

## Changes
- Updated `.image.featured` CSS to enforce consistent 4:3 aspect ratio
- Added `object-fit: cover` for proper image scaling and cropping
- Applied changes to both desktop and mobile responsive breakpoints
- Ensures all three featured images display uniformly

Closes #27

Generated with [Claude Code](https://claude.ai/code)